### PR TITLE
Remove test requiring computer with sv-SE locale

### DIFF
--- a/Date.spec.ts
+++ b/Date.spec.ts
@@ -19,9 +19,6 @@ describe("Date", () => {
 				expect(model.Date.localize(new Date(date[0]), "sv-SE")).toEqual(date[1])
 			)
 
-		for (const date of data)
-			it("localize without locale " + date[0], () => expect(model.Date.localize(new Date(date[0]))).toEqual(date[1]))
-
 		it("localize Date with locale", () => {
 			expect(model.Date.localize("2020-12-31", "en-US")).toEqual("12/31/2020")
 		})


### PR DESCRIPTION
Test compares date with sv-SE locale with locale on computer test is being run on. See image:

![Screenshot from 2021-04-14 16-03-24](https://user-images.githubusercontent.com/14332757/114723761-369fb680-9d3b-11eb-8af6-144fea10c76a.png)
