### PR TITLE
catch up to non-parity

### DIFF
--- a/Date.spec.ts
+++ b/Date.spec.ts
@@ -65,6 +65,14 @@ describe("Date", () => {
 		expect(isoly.Date.lastOfMonth("2001-02-01")).toEqual("2001-02-28")
 		expect(isoly.Date.lastOfMonth("2004-02-24")).toEqual("2004-02-29")
 	})
+	it("firstOfWeek", () => {
+		expect(isoly.Date.firstOfWeek("2000-01-01")).toEqual("1999-12-27")
+		expect(isoly.Date.firstOfWeek("2000-01-31")).toEqual("2000-01-31")
+	})
+	it("lastOfWeek", () => {
+		expect(isoly.Date.lastOfWeek("2000-01-01")).toEqual("2000-01-02")
+		expect(isoly.Date.lastOfWeek("2000-01-31")).toEqual("2000-02-06")
+	})
 	if (new Date(Date.UTC(2020, 11, 31, 23, 59, 59)).getTimezoneOffset() == -60) {
 		it("zero-pads localized", () => {
 			expect(isoly.Date.localize(new Date("4 Jul 2020 10:20:30 GMT"), "sv-SE")).toEqual("2020-07-04")

--- a/Date.ts
+++ b/Date.ts
@@ -91,6 +91,18 @@ export namespace Date {
 		result.setDate(0)
 		return Date.create(result)
 	}
+	export function firstOfWeek(date: Date): Date {
+		const result = parse(date)
+		const relativeDay = result.getDate() - result.getDay() + 1
+		result.setDate(relativeDay)
+		return Date.create(result)
+	}
+	export function lastOfWeek(date: Date): Date {
+		const result = parse(date)
+		const relativeDay = result.getDate() - result.getDay() + 7
+		result.setDate(relativeDay)
+		return Date.create(result)
+	}
 	export function getYear(time: Date): number {
 		return Number.parseInt(time.substring(0, 4))
 	}

--- a/DateRange.spec.ts
+++ b/DateRange.spec.ts
@@ -1,18 +1,23 @@
-import * as model from "./DateRange"
+import { DateRange } from "./DateRange"
 describe("DateRange", () => {
 	it("create Date + Date", () => {
-		expect(model.DateRange.create("2021-01-01", "2020-01-01")).toEqual({ start: "2020-01-01", end: "2021-01-01" })
+		expect(DateRange.create("2021-01-01", "2020-01-01")).toEqual({ start: "2020-01-01", end: "2021-01-01" })
 	})
 	it("create Date + DateSpan", () => {
-		expect(model.DateRange.create("2001-01-01", { years: 1, months: 2, days: 3 })).toEqual({
+		expect(DateRange.create("2001-01-01", { years: 1, months: 2, days: 3 })).toEqual({
 			start: "2001-01-01",
 			end: "2002-03-04",
 		})
 	})
 	it("create Date - DateSpan", () => {
-		expect(model.DateRange.create("2001-01-01", { years: -1, months: -1, days: -1 })).toEqual({
+		expect(DateRange.create("2001-01-01", { years: -1, months: -1, days: -1 })).toEqual({
 			start: "1999-11-30",
 			end: "2001-01-01",
 		})
+	})
+	it("getDays", () => {
+		expect(DateRange.getDays({ start: "2022-04-30", end: "2022-05-20" })).toEqual(20)
+		expect(DateRange.getDays({ start: "2022-04-30", end: "2022-04-30" })).toEqual(0)
+		expect(DateRange.getDays({ start: "2022-05-20", end: "2022-04-30" })).toEqual(-20)
 	})
 })

--- a/DateRange.ts
+++ b/DateRange.ts
@@ -18,4 +18,14 @@ export namespace DateRange {
 			? { start, end }
 			: { start: end, end: start }
 	}
+	export function getDays(value: DateRange): number {
+		const result =
+			value.start <= value.end
+				? Math.ceil(
+						(new globalThis.Date(value.end).getTime() - new globalThis.Date(value.start).getTime()) / (1000 * 3600 * 24)
+				  )
+				: -getDays({ start: value.end, end: value.start })
+
+		return result
+	}
 }

--- a/DateTime.spec.ts
+++ b/DateTime.spec.ts
@@ -3,8 +3,11 @@ import * as isoly from "./index"
 describe("DateTime", () => {
 	it("create + is", () => {
 		const d = isoly.DateTime.create(new Date(Date.UTC(2020, 11, 31, 23, 59, 59)))
-		expect(isoly.DateTime.is(d))
+		expect(isoly.DateTime.is(d)).toEqual(true)
 		expect(d).toBe("2020-12-31T23:59:59.000Z")
+	})
+	it("epoch", () => {
+		expect(isoly.DateTime.epoch("2019-04-01T00:00:00.000Z")).toBe(1554076800)
 	})
 	if (new Date(Date.UTC(2020, 11, 31, 23, 59, 59)).getTimezoneOffset() == -60) {
 		it("zero-pads localized", () => {

--- a/TimeSpan.spec.ts
+++ b/TimeSpan.spec.ts
@@ -1,0 +1,14 @@
+import { TimeSpan } from "./TimeSpan"
+describe("TimeSpan", () => {
+	it("Timespan to Unit", () => {
+		expect(TimeSpan.toMilliseconds({ hours: 0.75, minutes: 14, seconds: 59, milliseconds: 1000 })).toEqual(3600000)
+		expect(TimeSpan.toMinutes({ hours: 1, minutes: 10, seconds: 44, milliseconds: 1000 })).toEqual(70.75)
+		expect(TimeSpan.toSeconds({ hours: 0.75, minutes: 14, seconds: 59, milliseconds: 1000 })).toEqual(3600)
+		expect(TimeSpan.toHours({ hours: 1, minutes: 14, seconds: 59, milliseconds: 1000 })).toEqual(1.25)
+	})
+	it("Timespan to Round Unit", () => {
+		expect(TimeSpan.toMinutes({ hours: 1, minutes: 10, seconds: 50, milliseconds: 30 }, "round")).toEqual(71)
+		expect(TimeSpan.toMinutes({ hours: 1, minutes: 10, seconds: 50, milliseconds: 30 }, "ceiling")).toEqual(71)
+		expect(TimeSpan.toMinutes({ hours: 1, minutes: 10, seconds: 50, milliseconds: 30 }, "floor")).toEqual(70)
+	})
+})

--- a/TimeSpan.ts
+++ b/TimeSpan.ts
@@ -27,4 +27,44 @@ export namespace TimeSpan {
 				typeof value.milliseconds == "number")
 		)
 	}
+	export function toHours(value: TimeSpan, round?: Round): number {
+		const result =
+			(value.milliseconds ?? 0) / (60 * 60 * 1000) +
+			(value.seconds ?? 0) / (60 * 60) +
+			(value.minutes ?? 0) / 60 +
+			(value.hours ?? 0)
+		return performRound(result, round)
+	}
+	export function toMinutes(value: TimeSpan, round?: Round): number {
+		const result =
+			(value.milliseconds ?? 0) / (60 * 1000) +
+			(value.seconds ?? 0) / 60 +
+			(value.minutes ?? 0) +
+			(value.hours ?? 0) * 60
+		return performRound(result, round)
+	}
+	export function toSeconds(value: TimeSpan, round?: Round): number {
+		const result =
+			(value.milliseconds ?? 0) / 1000 + (value.seconds ?? 0) + (value.minutes ?? 0) * 60 + (value.hours ?? 0) * 60 * 60
+		return performRound(result, round)
+	}
+	export function toMilliseconds(value: TimeSpan, round?: Round): number {
+		const result =
+			(value.milliseconds ?? 0) +
+			(value.seconds ?? 0) * 1000 +
+			(value.minutes ?? 0) * 60 * 1000 +
+			(value.hours ?? 0) * 60 * 60 * 1000
+		return performRound(result, round)
+	}
+}
+
+type Round = "round" | "floor" | "ceiling"
+function performRound(value: number, round?: Round): number {
+	return !round
+		? value
+		: round == "ceiling"
+		? Math.ceil(value)
+		: round == "floor"
+		? Math.floor(value)
+		: Math.round(value)
 }


### PR DESCRIPTION
These are fixes/features that have already been added to the regular master, but not to parity.
## first last week

- `Date.firstOfWeek` with tests
- `Date.lastOfWeek` with tests
#80 
## getDays

- `Date.getDays` with tests
#84
## #Add Epoch test
- Add Epoch test
#85

## Add TimeSpan to unit
- `TimeSpan.toMilliseconds` with tests
- `TimeSpan.toMinutes` with tests
- `TimeSpan.toSeconds` with tests
- `TimeSpan.toHours` with tests
#85