### PR TITLE
fixed date validation.

### DIFF
--- a/Date.ts
+++ b/Date.ts
@@ -9,7 +9,7 @@ export namespace Date {
 			typeof value == "string" &&
 			value.length == 10 &&
 			new globalThis.Date(value).toString() != "Invalid Date" &&
-			localize(value) == value
+			create(new globalThis.Date(value)) == value
 		)
 	}
 	export function parse(value: Date, time?: string): globalThis.Date {

--- a/Date.ts
+++ b/Date.ts
@@ -9,7 +9,7 @@ export namespace Date {
 			typeof value == "string" &&
 			value.length == 10 &&
 			new globalThis.Date(value).toString() != "Invalid Date" &&
-			create(new globalThis.Date(value)) == value
+			localize(value) == value
 		)
 	}
 	export function parse(value: Date, time?: string): globalThis.Date {

--- a/Date.ts
+++ b/Date.ts
@@ -8,7 +8,8 @@ export namespace Date {
 		return (
 			typeof value == "string" &&
 			value.length == 10 &&
-			/^(\d{4}-[01]\d-[0-3]\d)|(\d{4}-[01]\d-[0-3]\d)|(\d{4}-[01]\d-[0-3]\d)$/.test(value)
+			new globalThis.Date(value).toString() != "Invalid Date" &&
+			create(new globalThis.Date(value)) == value
 		)
 	}
 	export function parse(value: Date, time?: string): globalThis.Date {


### PR DESCRIPTION
Date.is("2010-13-32") return true
broken.
The changes can validate date properly when the format is ISO (YYYY-MM-DD), which makes sense as it's isoly
When it comes to other format like dd/mm/yyyy, it doesn't work out.