### PR TITLE
FIxed typo and clearified weekday output

### DIFF
--- a/Date.spec.ts
+++ b/Date.spec.ts
@@ -100,10 +100,13 @@ describe("Date", () => {
 		expect(isoly.DateTime.getDay("2020-12-31")).toEqual(31)
 	})
 	it("getWeekDay", () => {
-		expect(isoly.Date.getWeekDay("2022-05-11")).toEqual(3)
-		expect(isoly.Date.getWeekDay("2022-05-02")).toEqual(1)
-		expect(isoly.Date.getWeekDay("2022-05-07")).toEqual(6)
-		expect(isoly.Date.getWeekDay("2022-05-08")).toEqual(0)
+		expect(isoly.Date.getWeekDay("2022-05-02")).toEqual(1) // Monday
+		expect(isoly.Date.getWeekDay("2022-05-03")).toEqual(2) // Tuesday
+		expect(isoly.Date.getWeekDay("2022-05-04")).toEqual(3) // Wednesday
+		expect(isoly.Date.getWeekDay("2022-05-05")).toEqual(4) // Thursday
+		expect(isoly.Date.getWeekDay("2022-05-06")).toEqual(5) // Friday
+		expect(isoly.Date.getWeekDay("2022-05-07")).toEqual(6) // Saturday
+		expect(isoly.Date.getWeekDay("2022-05-08")).toEqual(0) // Sunday
 	})
 	it("invalid date", () => {
 		expect(isoly.Date.is("2020-13-31")).toEqual(false)

--- a/DateTime.spec.ts
+++ b/DateTime.spec.ts
@@ -170,5 +170,8 @@ describe("DateTime", () => {
 			expect(minutes).toEqual("2020-12-31T23:59Z")
 			expect(isoly.DateTime.is(minutes)).toEqual(true)
 		})
+		it("previousMillisecond", () => {
+			expect(isoly.DateTime.previousMillisecond("2020-01-01T00:00:00.100Z", 200)).toEqual("2019-12-31T23:59:59.900Z")
+		})
 	}
 })

--- a/DateTime.ts
+++ b/DateTime.ts
@@ -270,8 +270,8 @@ export namespace DateTime {
 		result.setMilliseconds(result.getMilliseconds() + milliseconds)
 		return DateTime.create(result)
 	}
-	export function previousMillisecond(time: DateTime, seconds = 1): DateTime {
-		return nextMillisecond(time, -seconds)
+	export function previousMillisecond(time: DateTime, milliseconds = 1): DateTime {
+		return nextMillisecond(time, -milliseconds)
 	}
 	export function nextSecond(time: DateTime, seconds = 1): DateTime {
 		const result = parse(time)


### PR DESCRIPTION
- fixed argument typo `seconds` -> `milliseconds`
- Added test for `DateTime.previousMilliseconds`
- Clarified weekday output with spec comments from `Date.getWeekday` function