### PR TITLE
sundays work now

### DIFF
--- a/Date.spec.ts
+++ b/Date.spec.ts
@@ -95,8 +95,10 @@ describe("Date", () => {
 		expect(isoly.Date.lastOfMonth("2004-02-24")).toEqual("2004-02-29")
 	})
 	it("firstOfWeek", () => {
+		expect(isoly.Date.firstOfWeek("2023-01-08")).toEqual("2023-01-02")
 		expect(isoly.Date.firstOfWeek("2000-01-01")).toEqual("1999-12-27")
 		expect(isoly.Date.firstOfWeek("2000-01-31")).toEqual("2000-01-31")
+		expect(isoly.Date.firstOfWeek("2023-02-05")).toEqual("2023-01-30")
 	})
 	it("lastOfWeek", () => {
 		expect(isoly.Date.lastOfWeek("2000-01-01")).toEqual("2000-01-02")

--- a/Date.spec.ts
+++ b/Date.spec.ts
@@ -96,6 +96,12 @@ describe("Date", () => {
 	})
 	it("firstOfWeek", () => {
 		expect(isoly.Date.firstOfWeek("2023-01-08")).toEqual("2023-01-02")
+		expect(isoly.Date.firstOfWeek("2023-01-06")).toEqual("2023-01-02")
+		expect(isoly.Date.firstOfWeek("2023-01-05")).toEqual("2023-01-02")
+		expect(isoly.Date.firstOfWeek("2023-01-04")).toEqual("2023-01-02")
+		expect(isoly.Date.firstOfWeek("2023-01-03")).toEqual("2023-01-02")
+		expect(isoly.Date.firstOfWeek("2023-01-02")).toEqual("2023-01-02")
+
 		expect(isoly.Date.firstOfWeek("2000-01-01")).toEqual("1999-12-27")
 		expect(isoly.Date.firstOfWeek("2000-01-31")).toEqual("2000-01-31")
 		expect(isoly.Date.firstOfWeek("2023-02-05")).toEqual("2023-01-30")

--- a/Date.spec.ts
+++ b/Date.spec.ts
@@ -96,6 +96,7 @@ describe("Date", () => {
 	})
 	it("firstOfWeek", () => {
 		expect(isoly.Date.firstOfWeek("2023-01-08")).toEqual("2023-01-02")
+		expect(isoly.Date.firstOfWeek("2023-01-07")).toEqual("2023-01-02")
 		expect(isoly.Date.firstOfWeek("2023-01-06")).toEqual("2023-01-02")
 		expect(isoly.Date.firstOfWeek("2023-01-05")).toEqual("2023-01-02")
 		expect(isoly.Date.firstOfWeek("2023-01-04")).toEqual("2023-01-02")

--- a/Date.ts
+++ b/Date.ts
@@ -111,7 +111,7 @@ export namespace Date {
 	}
 	export function firstOfWeek(date: Date): Date {
 		const result = parse(date)
-		const relativeDay = result.getDate() - result.getDay() + 1
+		const relativeDay = result.getDate() - (result.getDay() || 7) + 1
 		result.setDate(relativeDay)
 		return Date.create(result)
 	}

--- a/DateTime.spec.ts
+++ b/DateTime.spec.ts
@@ -292,4 +292,9 @@ describe("DateTime", () => {
 			"2023-01-16T14:00:00+00:00"
 		)
 	})
+	it("testing", () => {
+		const first = "2023-08-09T13:55:56.370Z"
+		const second = "2023-08-09T13:56:04.098Z"
+		console.log(isoly.TimeSpan.toMilliseconds(isoly.DateTime.span(second, first)))
+	})
 })

--- a/DateTime.spec.ts
+++ b/DateTime.spec.ts
@@ -292,9 +292,4 @@ describe("DateTime", () => {
 			"2023-01-16T14:00:00+00:00"
 		)
 	})
-	it("testing", () => {
-		const first = "2023-08-09T13:55:56.370Z"
-		const second = "2023-08-09T13:56:04.098Z"
-		console.log(isoly.TimeSpan.toMilliseconds(isoly.DateTime.span(second, first)))
-	})
 })


### PR DESCRIPTION
When calculating first day of the week on a Sunday it produced the following Monday instead of the previous Monday.
* calculating first day of week on Sunday produces previous Monday.