### PR TITLE
build: generate both es modules and commonjs

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
 	"files.exclude": {
 		".*": true,
+		"*.sh": true,
 		"*.json": true,
 		"CODEOWNERS": true,
 		"dist": true,

--- a/fixup.sh
+++ b/fixup.sh
@@ -1,13 +1,10 @@
-cat >dist/cjs/package.json <<!EOF
-{
+echo >dist/cjs/package.json '{
   "type": "commonjs",
 	"typings": "dist/cjs/index.d.ts"
-}
-!EOF
+}'
 
-cat >dist/mjs/package.json <<!EOF
-{
+echo >dist/mjs/package.json '{
   "type": "module",
 	"typings": "dist/mjs/index.d.ts"
-}
-!EOF
+}'
+

--- a/fixup.sh
+++ b/fixup.sh
@@ -1,0 +1,13 @@
+cat >dist/cjs/package.json <<!EOF
+{
+  "type": "commonjs",
+	"typings": "dist/cjs/index.d.ts"
+}
+!EOF
+
+cat >dist/mjs/package.json <<!EOF
+{
+  "type": "module",
+	"typings": "dist/mjs/index.d.ts"
+}
+!EOF

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
 	"scripts": {
 		"lint": "eslint '**/*.{ts,tsx}'",
 		"fix": "eslint '**/*.{ts,tsx}' --fix",
-		"build": "rm -fr dist/* && tsc -p tsconfig.json && tsc -p tsconfig-cjs.json && ./fixup.sh",
+		"build": "rimraf dist/* && tsc -p tsconfig.json && tsc -p tsconfig-cjs.json && ./fixup.sh",
 		"test": "jest",
 		"prepare": "npm run build",
 		"clean": "rimraf dist node_modules coverage"

--- a/package.json
+++ b/package.json
@@ -10,9 +10,20 @@
 	},
 	"homepage": "https://github.com/utily",
 	"private": false,
-	"main": "dist/index.js",
-	"typings": "dist/index.d.ts",
-	"type": "module",
+	"main": "dist/cjs/index.js",
+	"module": "dist/mjs/index.js",
+	"exports": {
+		".": {
+			"import": {
+				"types": "./types/mjs/index.d.ts",
+				"default": "./dist/mjs/index.js"
+			},
+			"require": {
+				"types": "./types/cjs/index.d.ts",
+				"default": "./dist/cjs/index.js"
+			}
+		}
+	},
 	"git": {
 		"tagName": "v${version}"
 	},
@@ -46,7 +57,7 @@
 	"scripts": {
 		"lint": "eslint '**/*.{ts,tsx}'",
 		"fix": "eslint '**/*.{ts,tsx}' --fix",
-		"build": "tsc -p .",
+		"build": "rm -fr dist/* && tsc -p tsconfig.json && tsc -p tsconfig-cjs.json && ./fixup.sh",
 		"test": "jest",
 		"prepare": "npm run build",
 		"clean": "rimraf dist node_modules coverage"

--- a/tsconfig-cjs.json
+++ b/tsconfig-cjs.json
@@ -1,0 +1,8 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"module": "commonjs",
+		"outDir": "dist/cjs",
+		"target": "es2015"
+	}
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,9 +4,9 @@
 		"declaration": true,
 		"sourceMap": true,
 		"sourceRoot": "../",
-		"outDir": "dist",
+		"outDir": "dist/mjs",
 		"baseUrl": ".",
-		"allowSyntheticDefaultImports":true,
+		"allowSyntheticDefaultImports": true,
 		"types": []
 	},
 	"files": [

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -16,7 +16,7 @@
 		"noImplicitThis": true,
 		"strictNullChecks": true,
 		"sourceMap": true,
-		"outDir": "dist",
+		"outDir": "dist/mjs",
 		"moduleResolution": "node",
 		"resolveJsonModule": true,
 		"paths": {


### PR DESCRIPTION
(To fully generate valid es module distribution the typescript code should import files with specific path and file extension, but since this is a bigger change and not the case right now on master branch this will not be done in this PR)