### PR TITLE
fix: time format bug with node and or azure

### DIFF
--- a/DateTime.spec.ts
+++ b/DateTime.spec.ts
@@ -292,4 +292,10 @@ describe("DateTime", () => {
 			"2023-01-16T14:00:00+00:00"
 		)
 	})
+	it("fixIncorrect milliseconds", () => {
+		expect(isoly.DateTime.fixIncorrect("2023-10-31T11:23:40.8Z")).toEqual("2023-10-31T11:23:40.800Z")
+		expect(isoly.DateTime.fixIncorrect("2023-10-31T11:23:40.81Z")).toEqual("2023-10-31T11:23:40.810Z")
+		expect(isoly.DateTime.fixIncorrect("2023-10-31T11:23:40Z")).toEqual("2023-10-31T11:23:40Z")
+		expect(isoly.DateTime.fixIncorrect("2023-10-31T11:23:40.000Z")).toEqual("2023-10-31T11:23:40.000Z")
+	})
 })

--- a/DateTime.ts
+++ b/DateTime.ts
@@ -86,7 +86,14 @@ export namespace DateTime {
 			}
 			value = new globalThis.Date(value)
 		}
-		return value.toISOString()
+		return fixIncorrect(value.toISOString())
+	}
+	export function fixIncorrect(value: DateTime | string): DateTime {
+		if (value.length == 22 && value.match(/\.\dZ$/))
+			value = value.substring(0, 21) + "00Z"
+		else if (value.length == 23 && value.match(/\.\d\dZ$/))
+			value = value.substring(0, 22) + "0Z"
+		return value
 	}
 	/**
 	 * Return local time with offset.


### PR DESCRIPTION
In azure using node 18 we sometimes get datetime strings with incorrect number of millisecond digits