### PR TITLE
fix: TimeSpans from negative time

### DIFF
--- a/TimeSpan.spec.ts
+++ b/TimeSpan.spec.ts
@@ -70,6 +70,7 @@ describe("TimeSpan", () => {
 		expect(isoly.TimeSpan.fromMilliseconds(time)).toEqual({
 			minutes: 18,
 		})
+		expect(isoly.TimeSpan.fromMilliseconds(-60_001)).toEqual({ minutes: -1, milliseconds: -1 })
 	})
 	it("fromSeconds", () => {
 		const seconds = 1_234.56
@@ -97,6 +98,8 @@ describe("TimeSpan", () => {
 		expect(isoly.TimeSpan.fromSeconds(time)).toEqual({
 			minutes: 18,
 		})
+		expect(isoly.TimeSpan.fromSeconds(-61)).toEqual({ minutes: -1, seconds: -1 })
+		expect(isoly.TimeSpan.fromSeconds(-1.5)).toEqual({ seconds: -1, milliseconds: -500 })
 	})
 	it("fromMinutes", () => {
 		const minutes = 20.576
@@ -120,6 +123,8 @@ describe("TimeSpan", () => {
 		expect(isoly.TimeSpan.fromMinutes(time)).toEqual({
 			minutes: 18,
 		})
+		expect(isoly.TimeSpan.fromMinutes(-61)).toEqual({ hours: -1, minutes: -1 })
+		expect(isoly.TimeSpan.fromMinutes(-1.5)).toEqual({ minutes: -1, seconds: -30 })
 	})
 	it("fromHours", () => {
 		const hours = 0.34293333333333337
@@ -145,6 +150,8 @@ describe("TimeSpan", () => {
 		expect(isoly.TimeSpan.fromHours(time)).toEqual({
 			minutes: 18,
 		})
+		expect(isoly.TimeSpan.fromHours(-25)).toEqual({ hours: -25 })
+		expect(isoly.TimeSpan.fromHours(-1.5)).toEqual({ hours: -1, minutes: -30 })
 		// handle bad floating point math
 		// 6.4 - 4 == 2.4000000000000004
 		expect(isoly.TimeSpan.fromHours(6.4 - 4, { precision: "milliseconds" })).toEqual({ hours: 2, minutes: 24 })

--- a/TimeSpan.ts
+++ b/TimeSpan.ts
@@ -122,7 +122,7 @@ export namespace TimeSpan {
 			result = sum(
 				{ minutes: minutes % 60 },
 				fromSeconds(remainder * 60, { precision }),
-				minutes < 60 ? {} : fromHours(Math.trunc(minutes / 60), { precision: "hours" })
+				Math.abs(minutes) < 60 ? {} : fromHours(Math.trunc(minutes / 60), { precision: "hours" })
 			)
 		else {
 			const rounded = minutes + Math.round(remainder)
@@ -139,7 +139,7 @@ export namespace TimeSpan {
 			result = sum(
 				{ seconds: seconds % 60 },
 				fromMilliseconds(remainder * 1000),
-				seconds < 60 ? {} : fromMinutes(Math.trunc(seconds / 60), { precision: "minutes" })
+				Math.abs(seconds) < 60 ? {} : fromMinutes(Math.trunc(seconds / 60), { precision: "minutes" })
 			)
 		else {
 			const rounded = seconds + Math.round(remainder)
@@ -151,7 +151,7 @@ export namespace TimeSpan {
 		const rounded = Math.round(value)
 		return sum(
 			{ milliseconds: rounded % 1000 },
-			rounded < 1000 ? {} : fromSeconds(Math.trunc(rounded / 1000), { precision: "seconds" })
+			Math.abs(rounded) < 1000 ? {} : fromSeconds(Math.trunc(rounded / 1000), { precision: "seconds" })
 		)
 	}
 	const from = {


### PR DESCRIPTION
* from functions could not create units of negative time if the unit was "higher" than what was processed.