### PR TITLE
Empty timespans

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: current
+          node-version: 20.10.0
           cache: 'npm'
       - run: npm install
       - run: npm run build
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: current
+          node-version: 20.10.0
           cache: 'npm'
       - run: npm install
       - run: npm run lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: current
+          node-version: 20.10.0
           cache: 'npm'
       - run: npm install
       - run: npm run test

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -29,8 +29,8 @@
 	"editor.formatOnSave": true,
 	"editor.formatOnPaste": true,
 	"editor.codeActionsOnSave": {
-		"source.fixAll.eslint": true,
-		"eslint.autoFixOnSave": true,
+		"source.fixAll.eslint": "explicit",
+		"eslint.autoFixOnSave": "explicit"
 	},
 	"eslint.format.enable": true,
 	"eslint.lintTask.enable": true,

--- a/DateSpan.spec.ts
+++ b/DateSpan.spec.ts
@@ -1,0 +1,11 @@
+import { isoly } from "./index"
+
+describe("DateSpan", () => {
+	it("is", () => {
+		expect(isoly.DateSpan.is({})).toEqual(true)
+		expect(isoly.DateSpan.is({ days: 0.75, months: 14, years: 59 })).toEqual(true)
+		expect(isoly.DateSpan.is({ days: "4" })).toEqual(false)
+		expect(isoly.DateSpan.is([0.75, 14, 59, 1000])).toEqual(false)
+		expect(isoly.DateSpan.is(null)).toEqual(false)
+	})
+})

--- a/DateSpan.ts
+++ b/DateSpan.ts
@@ -8,6 +8,8 @@ export namespace DateSpan {
 	export function is(value: DateSpan | any): value is DateSpan {
 		return (
 			typeof value == "object" &&
+			!!value &&
+			!Array.isArray(value) &&
 			(typeof value.years == "number" || value.years == undefined) &&
 			(typeof value.months == "number" || value.months == undefined) &&
 			(typeof value.days == "number" || value.days == undefined)

--- a/DateSpan.ts
+++ b/DateSpan.ts
@@ -10,8 +10,7 @@ export namespace DateSpan {
 			typeof value == "object" &&
 			(typeof value.years == "number" || value.years == undefined) &&
 			(typeof value.months == "number" || value.months == undefined) &&
-			(typeof value.days == "number" || value.days == undefined) &&
-			(typeof value.years == "number" || typeof value.months == "number" || typeof value.days == "number")
+			(typeof value.days == "number" || value.days == undefined)
 		)
 	}
 }

--- a/DateTime.ts
+++ b/DateTime.ts
@@ -106,27 +106,19 @@ export namespace DateTime {
 
 		// Create a Date object with the specified time as UTC
 		const utcDateTime = new globalThis.Date(`${localDateTime}Z`)
-		console.log("utcDateTime", utcDateTime)
 
 		const localDate = new globalThis.Date(
 			utcDateTime.toLocaleString("sv-SE", { timeZone: timeZone }).replace(" ", "T") + "Z"
 		)
-		console.log(
-			"some invalid date?",
-			utcDateTime.toLocaleString("sv-SE", { timeZone: timeZone }).replace(" ", "T") + "Z"
-		)
-		console.log("localeDate", localDate)
-
 		// Calculate the time difference in minutes
 		const diffInMinutes = (localDate.getTime() - utcDateTime.getTime()) / 60000
-		console.log("diffInMinutes", diffInMinutes)
+
 		// Calculate the timezone's offset in hours and minutes
 		const offsetHours = Math.floor(Math.abs(diffInMinutes) / 60)
 			.toString()
 			.padStart(2, "0")
-		console.log("offsetHours", offsetHours)
 		const offsetMinutes = (Math.abs(diffInMinutes) % 60).toString().padStart(2, "0")
-		console.log("offsetMinutes", offsetMinutes)
+
 		// Create the timezone string
 		const timeZoneString = `${diffInMinutes >= 0 ? "+" : "-"}${offsetHours}:${offsetMinutes}`
 

--- a/DateTime.ts
+++ b/DateTime.ts
@@ -111,6 +111,10 @@ export namespace DateTime {
 		const localDate = new globalThis.Date(
 			utcDateTime.toLocaleString("sv-SE", { timeZone: timeZone }).replace(" ", "T") + "Z"
 		)
+		console.log(
+			"some invalid date?",
+			utcDateTime.toLocaleString("sv-SE", { timeZone: timeZone }).replace(" ", "T") + "Z"
+		)
 		console.log("localeDate", localDate)
 
 		// Calculate the time difference in minutes

--- a/DateTime.ts
+++ b/DateTime.ts
@@ -110,6 +110,7 @@ export namespace DateTime {
 		const localDate = new globalThis.Date(
 			utcDateTime.toLocaleString("sv-SE", { timeZone: timeZone }).replace(" ", "T") + "Z"
 		)
+
 		// Calculate the time difference in minutes
 		const diffInMinutes = (localDate.getTime() - utcDateTime.getTime()) / 60000
 

--- a/DateTime.ts
+++ b/DateTime.ts
@@ -106,20 +106,23 @@ export namespace DateTime {
 
 		// Create a Date object with the specified time as UTC
 		const utcDateTime = new globalThis.Date(`${localDateTime}Z`)
+		console.log("utcDateTime", utcDateTime)
 
 		const localDate = new globalThis.Date(
 			utcDateTime.toLocaleString("sv-SE", { timeZone: timeZone }).replace(" ", "T") + "Z"
 		)
+		console.log("localeDate", localDate)
 
 		// Calculate the time difference in minutes
 		const diffInMinutes = (localDate.getTime() - utcDateTime.getTime()) / 60000
-
+		console.log("diffInMinutes", diffInMinutes)
 		// Calculate the timezone's offset in hours and minutes
 		const offsetHours = Math.floor(Math.abs(diffInMinutes) / 60)
 			.toString()
 			.padStart(2, "0")
+		console.log("offsetHours", offsetHours)
 		const offsetMinutes = (Math.abs(diffInMinutes) % 60).toString().padStart(2, "0")
-
+		console.log("offsetMinutes", offsetMinutes)
 		// Create the timezone string
 		const timeZoneString = `${diffInMinutes >= 0 ? "+" : "-"}${offsetHours}:${offsetMinutes}`
 

--- a/TimeSpan.spec.ts
+++ b/TimeSpan.spec.ts
@@ -1,6 +1,13 @@
 import { isoly } from "./index"
 
 describe("TimeSpan", () => {
+	it("is", () => {
+		expect(isoly.TimeSpan.is({})).toEqual(true)
+		expect(isoly.TimeSpan.is({ hours: 0.75, minutes: 14, seconds: 59, milliseconds: 1000 })).toEqual(true)
+		expect(isoly.TimeSpan.is({ hours: "4" })).toEqual(false)
+		expect(isoly.TimeSpan.is([0.75, 14, 59, 1000])).toEqual(false)
+		expect(isoly.TimeSpan.is(null)).toEqual(false)
+	})
 	it("undefined", () => {
 		expect(isoly.TimeSpan.is(undefined)).toBeFalsy()
 	})

--- a/TimeSpan.ts
+++ b/TimeSpan.ts
@@ -17,14 +17,7 @@ export namespace TimeSpan {
 			(typeof value.hours == "number" || value.hours == undefined) &&
 			(typeof value.minutes == "number" || value.minutes == undefined) &&
 			(typeof value.seconds == "number" || value.seconds == undefined) &&
-			(typeof value.milliseconds == "number" || value.milliseconds == undefined) &&
-			(typeof value.years == "number" ||
-				typeof value.months == "number" ||
-				typeof value.days == "number" ||
-				typeof value.hours == "number" ||
-				typeof value.minutes == "number" ||
-				typeof value.seconds == "number" ||
-				typeof value.milliseconds == "number")
+			(typeof value.milliseconds == "number" || value.milliseconds == undefined)
 		)
 	}
 	export function toHours(value: TimeSpan, round?: Round): number {

--- a/TimeSpan.ts
+++ b/TimeSpan.ts
@@ -11,6 +11,8 @@ export namespace TimeSpan {
 	export function is(value: TimeSpan | any): value is TimeSpan {
 		return (
 			typeof value == "object" &&
+			!!value &&
+			!Array.isArray(value) &&
 			(typeof value.years == "number" || value.years == undefined) &&
 			(typeof value.months == "number" || value.months == undefined) &&
 			(typeof value.days == "number" || value.days == undefined) &&


### PR DESCRIPTION
Old is check did not allow empty objects as values even if they are fine to use in calculations. 
Many function in the TimeSpan namespace can return an empty object which would then not pass the is check.

Changed node version in CI from current (21.5.0) to current LTS (20.10.0) as some tests for DateTime locale strings broke in 21.5.0 (These functions broke but were untouched in this PR). 