### PR TITLE
Add function to count business days

### DIFF
--- a/Date.spec.ts
+++ b/Date.spec.ts
@@ -196,4 +196,23 @@ describe("Date", () => {
 			years: 0,
 		})
 	})
+	it("nextBusinessDay", () => {
+		expect(isoly.Date.nextBusinessDay("2022-05-04", 0)).toEqual("2022-05-04") // Wednesday -> Wednesday
+		expect(isoly.Date.nextBusinessDay("2022-05-04", 1)).toEqual("2022-05-05") // Wednesday -> Thursday
+		expect(isoly.Date.nextBusinessDay("2022-05-04", 2)).toEqual("2022-05-06") // Wednesday -> Friday
+		expect(isoly.Date.nextBusinessDay("2022-05-04", 3)).toEqual("2022-05-09") // Wednesday -> Monday
+		expect(isoly.Date.nextBusinessDay("2022-05-04", 4)).toEqual("2022-05-10") // Wednesday -> Tuesday
+		expect(isoly.Date.nextBusinessDay("2022-05-04", 5)).toEqual("2022-05-11") // Wednesday -> Wednesday
+		expect(isoly.Date.nextBusinessDay("2022-05-04", 6)).toEqual("2022-05-12") // Wednesday -> Thursday
+		expect(isoly.Date.nextBusinessDay("2022-05-07", 0)).toEqual("2022-05-09") // Saturday -> Monday
+		expect(isoly.Date.nextBusinessDay("2022-05-07", 1)).toEqual("2022-05-09") // Saturday -> Monday
+		expect(isoly.Date.nextBusinessDay("2022-05-07", 2)).toEqual("2022-05-10") // Saturday -> Tuesday
+		expect(isoly.Date.nextBusinessDay("2022-05-07", 3)).toEqual("2022-05-11") // Saturday -> Wednesday
+		expect(isoly.Date.nextBusinessDay("2022-05-04", 1, ["2022-05-05", "2022-05-06"])).toEqual("2022-05-09") // Saturday -> Monday
+		expect(isoly.Date.nextBusinessDay("2022-05-04", 2, ["2022-05-05", "2022-05-06"])).toEqual("2022-05-10") // Saturday -> Tuesday
+		expect(isoly.Date.nextBusinessDay("2022-05-04", 3, ["2022-05-05", "2022-05-06"])).toEqual("2022-05-11") // Saturday -> Wednesday
+		expect(
+			isoly.Date.nextBusinessDay("2022-05-04", 3, ["2022-05-05", "2022-05-06", "2022-05-10", "2022-05-11"])
+		).toEqual("2022-05-13") // Saturday -> Friday
+	})
 })

--- a/Date.ts
+++ b/Date.ts
@@ -159,6 +159,18 @@ export namespace Date {
 		}
 		return result
 	}
+	export function nextBusinessDay(date: Date, bankingDays = 1, bankingHolidays: Date[] | Set<Date> = []): Date {
+		const holidaySet = new Set(bankingHolidays)
+		if (bankingDays <= 0 && isBusinessDay(date, holidaySet))
+			return date
+		const tomorrow = next(date)
+		const tomorrowIsBusinessDay = isBusinessDay(tomorrow, holidaySet)
+		return nextBusinessDay(tomorrow, tomorrowIsBusinessDay ? bankingDays - 1 : bankingDays, holidaySet)
+	}
+	function isBusinessDay(date: Date, holidaySet: Set<Date> = new Set()) {
+		const weekday = getWeekDay(date)
+		return !(weekday == 6 || weekday == 0 || holidaySet.has(date))
+	}
 	export function span(date: Date, relative: Date): DateSpan {
 		return {
 			years: getYear(date) - getYear(relative),


### PR DESCRIPTION
Add `nextBusinessDay` function.

This function counts the number of busness days which is different from `nextWeekday` which just rounds up to nearest business date.