### PR TITLE
fix: more resilient to decimals

### DIFF
--- a/TimeSpan.spec.ts
+++ b/TimeSpan.spec.ts
@@ -134,6 +134,8 @@ describe("TimeSpan", () => {
 		expect(isoly.TimeSpan.fromMinutes(-1.5)).toEqual({ minutes: -1, seconds: -30 })
 	})
 	it("fromHours", () => {
+		expect(isoly.TimeSpan.fromHours(-1.5)).toEqual({ hours: -1, minutes: -30 })
+
 		const hours = 0.34293333333333337
 		expect(isoly.TimeSpan.fromHours(hours, { precision: "milliseconds" })).toEqual({
 			minutes: 20,
@@ -166,33 +168,40 @@ describe("TimeSpan", () => {
 		expect(isoly.TimeSpan.fromHours(6.4 - 4 - 0.4, { precision: "milliseconds" })).toEqual({ hours: 2 })
 	})
 	it("normalize", () => {
-		let span: isoly.TimeSpan = { hours: 1, minutes: -123, seconds: 56, milliseconds: 996 }
-		let result = isoly.TimeSpan.normalize(span)
+		let span: isoly.TimeSpan
+		let result: isoly.TimeSpan
+
+		span = { hours: 0.12 }
+		result = isoly.TimeSpan.normalize(span)
+		expect(result).toEqual({ minutes: 7, seconds: 12 })
+
+		span = { hours: 1, minutes: -123, seconds: 56, milliseconds: 996 }
+		result = isoly.TimeSpan.normalize(span)
 		expect(isoly.TimeSpan.toMilliseconds(result)).toEqual(isoly.TimeSpan.toMilliseconds(span))
 		expect(result).toEqual({ hours: -1, minutes: -2, seconds: -3, milliseconds: -4 })
 
 		span = { hours: 2, minutes: -244, seconds: 4, milliseconds: 5 }
 		result = isoly.TimeSpan.normalize(span)
-		expect(isoly.TimeSpan.toMilliseconds(isoly.TimeSpan.normalize(span))).toEqual(isoly.TimeSpan.toMilliseconds(span))
+		expect(isoly.TimeSpan.toMilliseconds(result)).toEqual(isoly.TimeSpan.toMilliseconds(span))
 
 		span = { hours: 1, minutes: -60, seconds: -4, milliseconds: 4001 }
 		result = isoly.TimeSpan.normalize(span)
-		expect(isoly.TimeSpan.toMilliseconds(isoly.TimeSpan.normalize(span))).toEqual(isoly.TimeSpan.toMilliseconds(span))
+		expect(isoly.TimeSpan.toMilliseconds(result)).toEqual(isoly.TimeSpan.toMilliseconds(span))
 		expect(result).toEqual({ milliseconds: 1 })
 
 		span = { milliseconds: 3723004 }
 		result = isoly.TimeSpan.normalize(span)
-		expect(isoly.TimeSpan.toMilliseconds(isoly.TimeSpan.normalize(span))).toEqual(isoly.TimeSpan.toMilliseconds(span))
+		expect(isoly.TimeSpan.toMilliseconds(result)).toEqual(isoly.TimeSpan.toMilliseconds(span))
 		expect(result).toEqual({ hours: 1, minutes: 2, seconds: 3, milliseconds: 4 })
 
 		span = { hours: 1.6, minutes: 4 }
 		result = isoly.TimeSpan.normalize(span)
-		expect(isoly.TimeSpan.toMilliseconds(isoly.TimeSpan.normalize(span))).toEqual(isoly.TimeSpan.toMilliseconds(span))
+		expect(isoly.TimeSpan.toMilliseconds(result)).toEqual(isoly.TimeSpan.toMilliseconds(span))
 		expect(result).toEqual({ hours: 1, minutes: 40 })
 
 		span = { hours: 0 }
 		result = isoly.TimeSpan.normalize(span)
-		expect(isoly.TimeSpan.toMilliseconds(isoly.TimeSpan.normalize(span))).toEqual(isoly.TimeSpan.toMilliseconds(span))
+		expect(isoly.TimeSpan.toMilliseconds(result)).toEqual(isoly.TimeSpan.toMilliseconds(span))
 		expect(result).toEqual({})
 	})
 })

--- a/TimeSpan.ts
+++ b/TimeSpan.ts
@@ -179,7 +179,6 @@ function dateToMilliseconds(span: TimeSpan): number {
 
 type Round = "round" | "floor" | "ceiling"
 function performRound(value: number, round?: Round): number {
-	// console.log("rounding", value)
 	return !round
 		? value
 		: round == "ceiling"

--- a/TimeSpan.ts
+++ b/TimeSpan.ts
@@ -146,13 +146,25 @@ export namespace TimeSpan {
 		return options?.normalize == false ? result : normalize(result)
 	}
 	export function normalize(value: TimeSpan): TimeSpan {
-		const result: TimeSpan = {
+		const result = {
 			milliseconds: Math.round(toMilliseconds(value) % 1000),
 			seconds: Math.trunc(toSeconds(value) % 60),
 			minutes: Math.trunc(toMinutes(value) % 60),
 			hours: Math.trunc(toHours(value)),
 		}
-		return Object.fromEntries(Object.entries(result).filter(([, value]) => value != 0))
+		if (!(-1000 < result.milliseconds && result.milliseconds < 1000)) {
+			result.seconds += Math.trunc(result.milliseconds / 1000)
+			result.milliseconds = result.milliseconds % 1000
+		}
+		if (!(-60 < result.seconds && result.seconds < 60)) {
+			result.minutes += Math.trunc(result.seconds / 60)
+			result.seconds = result.seconds % 60
+		}
+		if (!(-60 < result.minutes && result.minutes < 60)) {
+			result.hours += Math.trunc(result.minutes)
+			result.minutes = result.minutes % 60
+		}
+		return Object.fromEntries(Object.entries<number | undefined>(result).filter(([, value]) => !!value))
 	}
 }
 
@@ -173,6 +185,7 @@ function dateToMilliseconds(span: TimeSpan): number {
 
 type Round = "round" | "floor" | "ceiling"
 function performRound(value: number, round?: Round): number {
+	// console.log("rounding", value)
 	return !round
 		? value
 		: round == "ceiling"


### PR DESCRIPTION
`TimeSpan.normalize({hours: 0.12})` gave result `{minutes: 7, seconds: 11, milliseconds: 1000}` when `{minutes: 7, seconds: 12}` was expected.

Fixes:
If result from `TimeSpant.toSomeUnit(...)` results in a value that is at least a multiple of some larger unit it is transferred to that in a refining step. In this example this 1000 milliseconds is moved to be 1 seconds as 1000 is a multiple of seconds. 